### PR TITLE
Fix links to sample web js templates for map-with samples

### DIFF
--- a/map-with-geojson-line/README.md
+++ b/map-with-geojson-line/README.md
@@ -6,7 +6,7 @@ This sample app shows you how to add a GeoJSON line to a web map. It uses Amazon
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=geojson-line-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-geojson-line/template.yml)
+[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=geojson-line-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-map-with-geojson-line/template.yml)
 
 Once the deployment process is complete, go to the `Outputs` section to get the Cognito Identity Pool ID.
 

--- a/map-with-geojson-point/README.md
+++ b/map-with-geojson-point/README.md
@@ -6,7 +6,7 @@ This sample app shows you how to add a GeoJSON point to a web map. It uses Amazo
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=geojson-point-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-geojson-point/template.yml)
+[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=geojson-point-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-map-with-geojson-point/template.yml)
 
 Once the deployment process is complete, go to the `Outputs` section to get the Cognito Identity Pool ID.
 

--- a/map-with-geojson-polygon/README.md
+++ b/map-with-geojson-polygon/README.md
@@ -6,7 +6,7 @@ This sample app shows you how to add a GeoJSON polygon to a web map. It uses Ama
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=geojson-polygon-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-geojson-polygon/template.yml)
+[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=geojson-polygon-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-map-with-geojson-polygon/template.yml)
 
 Once the deployment process is complete, go to the `Outputs` section to get the Cognito Identity Pool ID.
 

--- a/map-with-marker-and-popup/README.md
+++ b/map-with-marker-and-popup/README.md
@@ -6,7 +6,7 @@ This sample app shows you how to add a marker with a popup to a web map. It uses
 
 Click the button below to create the necessary AWS resources for this sample app to run. It will open the AWS Management Console and initiate the CloudFormation template deployment process.
 
-[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=marker-with-popup-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-marker-with-popup/template.yml)
+[![Launch Stack](https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/cfn-launch-stack-button.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=marker-with-popup-example&templateURL=https://amazon-location-cloudformation-templates.s3.us-west-2.amazonaws.com/samples/web-js-map-with-marker-and-popup/template.yml)
 
 Once the deployment process is complete, go to the `Outputs` section to get the Cognito Identity Pool ID.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-geospatial/amazon-location-samples-js/issues/8

*Description of changes:*
This change corrects the links for the map-with* samples

Verified with checking each of the CFN+S3 links


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
